### PR TITLE
feat: Added array support

### DIFF
--- a/array.go
+++ b/array.go
@@ -1,0 +1,92 @@
+package schema
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+type ArraySchema struct {
+	Schema[[]interface{}]
+	schema ISchema
+}
+
+var _ ISchema = (*ArraySchema)(nil)
+
+func Array(s ISchema) *ArraySchema {
+	return &ArraySchema{schema: s}
+}
+
+func (s *ArraySchema) Max(maxLength int) *ArraySchema {
+	validator := Validator[[]interface{}]{
+		MessageFunc: func(value []interface{}) string {
+			return fmt.Sprintf("Array must contain at most %d element(s)", maxLength)
+		},
+		ValidateFunc: func(value []interface{}) bool {
+			return len(value) <= maxLength
+		},
+	}
+
+	s.validators = append(s.validators, validator)
+
+	return s
+}
+
+func (s *ArraySchema) Min(minLength int) *ArraySchema {
+	validator := Validator[[]interface{}]{
+		MessageFunc: func(value []interface{}) string {
+			return fmt.Sprintf("Array must contain at least %d element(s)", minLength)
+		},
+		ValidateFunc: func(value []interface{}) bool {
+			return len(value) >= minLength
+		},
+	}
+
+	s.validators = append(s.validators, validator)
+
+	return s
+}
+
+func (s *ArraySchema) Parse(value any) *ValidationResult {
+	t := reflect.TypeOf(value)
+
+	if t == nil || (t.Kind() != reflect.Array && t.Kind() != reflect.Slice) {
+		return &ValidationResult{Errors: []ValidationError{{Path: "", Message: fmt.Sprintf("Expected array, got %T", value)}}}
+	}
+
+	v := reflect.ValueOf(value)
+
+	val := make([]interface{}, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		val[i] = v.Index(i).Interface()
+	}
+
+	// Parse array validations
+	result := &ValidationResult{Errors: []ValidationError{}}
+
+	for _, validator := range s.validators {
+		if !validator.ValidateFunc(val) {
+			err := ValidationError{
+				Path:    "",
+				Message: validator.MessageFunc(val),
+			}
+
+			result.Errors = append(result.Errors, err)
+		}
+	}
+
+	// Parse schema validations within array for each item
+	for i := 0; i < len(val); i++ {
+		res := s.schema.Parse(val[i])
+
+		if !res.IsValid() {
+			for index, err := range res.Errors {
+				res.Errors[index].Path = formatPath(strconv.Itoa(i), err.Path)
+			}
+
+			result.Errors = append(result.Errors, res.Errors...)
+		}
+	}
+
+	return result
+}

--- a/array_test.go
+++ b/array_test.go
@@ -1,0 +1,102 @@
+package schema_test
+
+import (
+	"testing"
+
+	schema "github.com/Jamess-Lucass/validator-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArray_String_Type(t *testing.T) {
+	s := schema.Array(schema.String())
+
+	assert.True(t, s.Parse([]string{"one", "two"}).IsValid())
+	assert.True(t, s.Parse([]string{""}).IsValid())
+	assert.True(t, s.Parse([]string{}).IsValid())
+
+	assert.False(t, s.Parse(123).IsValid())
+	assert.False(t, s.Parse(nil).IsValid())
+	assert.False(t, s.Parse(map[string]int{
+		"one": 1,
+		"two": 2,
+	}).IsValid())
+	assert.False(t, s.Parse([]int{1, 2, 3}).IsValid())
+	assert.False(t, s.Parse(0).IsValid())
+	assert.False(t, s.Parse("57c6b6aa-211a-4b49-a012-3fd9b4a4ea2d").IsValid())
+	assert.False(t, s.Parse("db9fb12c-daea-11ee-a506-0242ac120002").IsValid())
+	assert.False(t, s.Parse("018e0e8f-b1d9-7503-ac4a-49b18a95be69").IsValid())
+	assert.False(t, s.Parse("00000000-0000-0000-0000-000000000000").IsValid())
+}
+
+func TestArray_Path(t *testing.T) {
+	s := schema.Array(schema.String().Min(4)).Parse([]string{"one"})
+
+	assert.Len(t, s.Errors, 1)
+	assert.Equal(t, "0", s.Errors[0].Path)
+}
+
+func TestArray_String(t *testing.T) {
+	s := schema.Array(schema.String().Min(4).StartsWith("a"))
+
+	assert.True(t, s.Parse([]string{"aour", "aive"}).IsValid())
+	assert.True(t, s.Parse([]string{"aour"}).IsValid())
+	assert.True(t, s.Parse([]string{}).IsValid())
+
+	assert.False(t, s.Parse([]string{"one"}).IsValid())
+	assert.False(t, s.Parse([]string{"one", "four"}).IsValid())
+
+	assert.Len(t, s.Parse([]string{"ane", "aour"}).Errors, 1)
+	assert.Len(t, s.Parse([]string{"ane", "four"}).Errors, 2)
+	assert.Len(t, s.Parse([]string{"one", "four"}).Errors, 3)
+}
+
+func TestArray_Min(t *testing.T) {
+	s := schema.Array(schema.String()).Min(1)
+
+	assert.True(t, s.Parse([]string{"aour", "aive"}).IsValid())
+	assert.True(t, s.Parse([]string{"aour"}).IsValid())
+
+	assert.False(t, s.Parse([]string{}).IsValid())
+}
+
+func TestArray_Max(t *testing.T) {
+	s := schema.Array(schema.String()).Max(1)
+
+	assert.True(t, s.Parse([]string{"aour"}).IsValid())
+	assert.True(t, s.Parse([]string{}).IsValid())
+
+	assert.False(t, s.Parse([]string{"aour", "aive"}).IsValid())
+}
+
+func TestArray_Object(t *testing.T) {
+	type User struct {
+		Firstname string
+	}
+
+	s := schema.Array(schema.Object(map[string]schema.ISchema{
+		"Firstname": schema.String().Min(4),
+	}))
+
+	val := []User{
+		{Firstname: "1234"},
+		{Firstname: "1234"},
+	}
+
+	assert.True(t, s.Parse(val).IsValid())
+}
+
+func TestArray_Object_Path(t *testing.T) {
+	type User struct {
+		Firstname string
+	}
+
+	s := schema.Array(schema.Object(map[string]schema.ISchema{
+		"Firstname": schema.String().Min(4),
+	})).Parse([]User{
+		{Firstname: "123"},
+		{Firstname: "123"},
+	})
+
+	assert.Len(t, s.Errors, 2)
+	assert.Equal(t, "0.Firstname", s.Errors[0].Path)
+}

--- a/object.go
+++ b/object.go
@@ -31,11 +31,12 @@ func (s *ObjectSchema) Refine(predicate func(map[string]interface{}) bool) *Obje
 
 func (s *ObjectSchema) Parse(value any) *ValidationResult {
 	t := reflect.TypeOf(value)
-	val := reflect.ValueOf(value)
 
-	if t.Kind() != reflect.Struct {
+	if t == nil || t.Kind() != reflect.Struct {
 		return &ValidationResult{Errors: []ValidationError{{Path: "", Message: fmt.Sprintf("Expected struct, got %T", value)}}}
 	}
+
+	val := reflect.ValueOf(value)
 
 	res := &ValidationResult{}
 
@@ -56,7 +57,7 @@ func (s *ObjectSchema) Parse(value any) *ValidationResult {
 		if !result.IsValid() {
 			for _, err := range result.Errors {
 				newError := ValidationError{
-					Path:    key,
+					Path:    formatPath(key, err.Path),
 					Message: err.Message,
 				}
 
@@ -65,7 +66,7 @@ func (s *ObjectSchema) Parse(value any) *ValidationResult {
 		}
 	}
 
-	valueMap := StructToMap(value)
+	valueMap := structToMap(value)
 
 	for _, validator := range s.validators {
 		if !validator.ValidateFunc(valueMap) {
@@ -81,7 +82,7 @@ func (s *ObjectSchema) Parse(value any) *ValidationResult {
 	return res
 }
 
-func StructToMap(item interface{}) map[string]interface{} {
+func structToMap(item interface{}) map[string]interface{} {
 	result := map[string]interface{}{}
 
 	val := reflect.ValueOf(item)

--- a/object_test.go
+++ b/object_test.go
@@ -1,0 +1,75 @@
+package schema_test
+
+import (
+	"testing"
+
+	schema "github.com/Jamess-Lucass/validator-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestObject_Type(t *testing.T) {
+	type User struct {
+		Firstname string
+		Lastname  string
+	}
+
+	s := schema.Object(map[string]schema.ISchema{
+		"Firstname": schema.String().Min(2),
+		"Lastname":  schema.String().StartsWith("d"),
+	})
+
+	assert.True(t, s.Parse(User{Firstname: "john", Lastname: "doe"}).IsValid())
+
+	assert.False(t, s.Parse(User{Firstname: "john", Lastname: ""}).IsValid())
+	assert.False(t, s.Parse(User{Firstname: "", Lastname: "doe"}).IsValid())
+	assert.False(t, s.Parse(User{Firstname: "", Lastname: ""}).IsValid())
+	assert.False(t, s.Parse(123).IsValid())
+	assert.False(t, s.Parse(nil).IsValid())
+	assert.False(t, s.Parse(map[string]int{
+		"one": 1,
+		"two": 2,
+	}).IsValid())
+	assert.False(t, s.Parse([]int{1, 2, 3}).IsValid())
+	assert.False(t, s.Parse(0).IsValid())
+	assert.False(t, s.Parse("57c6b6aa-211a-4b49-a012-3fd9b4a4ea2d").IsValid())
+	assert.False(t, s.Parse("db9fb12c-daea-11ee-a506-0242ac120002").IsValid())
+	assert.False(t, s.Parse("018e0e8f-b1d9-7503-ac4a-49b18a95be69").IsValid())
+	assert.False(t, s.Parse("00000000-0000-0000-0000-000000000000").IsValid())
+}
+
+func TestObject_Path(t *testing.T) {
+	type User struct {
+		Firstname string
+		Lastname  string
+	}
+
+	s := schema.Object(map[string]schema.ISchema{
+		"Firstname": schema.String().Min(2),
+		"Lastname":  schema.String().StartsWith("d"),
+	}).Parse(User{Firstname: "", Lastname: ""})
+
+	assert.Len(t, s.Errors, 2)
+	assert.Equal(t, "Firstname", s.Errors[0].Path)
+	assert.Equal(t, "Lastname", s.Errors[1].Path)
+}
+
+func TestObject_ArrayObject_Path(t *testing.T) {
+	type Address struct {
+		Postcode string
+	}
+
+	type User struct {
+		Addresses []Address
+	}
+
+	s := schema.Object(map[string]schema.ISchema{
+		"Addresses": schema.Array(schema.Object(map[string]schema.ISchema{
+			"Postcode": schema.String().Min(4),
+		})),
+	}).Parse(User{
+		Addresses: []Address{{Postcode: "123"}},
+	})
+
+	assert.Len(t, s.Errors, 1)
+	assert.Equal(t, "Addresses.0.Postcode", s.Errors[0].Path)
+}

--- a/schema.go
+++ b/schema.go
@@ -69,3 +69,11 @@ func (s *Schema[T]) Parse(value any) *ValidationResult {
 
 	return res
 }
+
+func formatPath(key string, path string) string {
+	if path != "" {
+		return fmt.Sprintf("%s.%s", key, path)
+	}
+
+	return key
+}

--- a/string_test.go
+++ b/string_test.go
@@ -22,6 +22,13 @@ func TestString_Type(t *testing.T) {
 	assert.False(t, s.Parse(0).IsValid())
 }
 
+func TestString_Path(t *testing.T) {
+	s := schema.String().Min(4).Parse("123")
+
+	assert.Len(t, s.Errors, 1)
+	assert.Equal(t, "", s.Errors[0].Path)
+}
+
 func TestString_Max(t *testing.T) {
 	s := schema.String().Max(5)
 


### PR DESCRIPTION
Adds support for `schema.Array()`
Comes with functions:
- `Min`
- `Max`

takes an argument of any type that implements the `ISchema` interface.

examples:
```go
schema.Array(schema.String())
```

```go
schema.Array(schema.String()).Min(1)
// Requires at least 1 element in the array
```

```go
schema.Array(schema.String().Max(10)).Min(1)
// Requires at least 1 element in the array where the item has a max length of 10
```

```go
schema.Array(schema.Object(map[string]schema.ISchema{
    "Firstname": schema.String().Min(4),
}))

// An array of objects where the property `Firstname` must be a string of minimum 4 characters

// [{Firstname: "john"}, {Firstname: "Doe"}] // 1st is valid, 2nd is invalid
````