### PR TITLE
feat: Enabled custom primitives for basic types

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -49,8 +49,9 @@ func (s *Schema[T]) Refine(predicate func(T) bool) *Schema[T] {
 }
 
 func (s *Schema[T]) Parse(value any) *ValidationResult {
+	t := reflect.ValueOf(value).Kind().String()
 	val, ok := value.(T)
-	if !ok {
+	if !ok && t != reflect.TypeOf(val).String() {
 		return &ValidationResult{Errors: []ValidationError{{Path: "", Message: fmt.Sprintf("Expected %s, received %T", reflect.TypeOf(val).String(), value)}}}
 	}
 

--- a/string_test.go
+++ b/string_test.go
@@ -104,14 +104,14 @@ func TestString_EndsWith(t *testing.T) {
 	assert.False(t, s.Parse("3tes3t").IsValid())
 }
 
-type CatalogueMarginLevel string
-type CatalogueMargin int
+type catalogueMarginLevel string
+type catalogueMargin int
 
 func TestString_CustomPrimitive(t *testing.T) {
 	s := schema.String()
 
-	v := CatalogueMarginLevel("eebofleebo")
-	x := CatalogueMargin(123)
+	v := catalogueMarginLevel("eebofleebo")
+	x := catalogueMargin(123)
 
 	assert.True(t, s.Parse(v).IsValid())
 	assert.False(t, s.Parse(x).IsValid())

--- a/string_test.go
+++ b/string_test.go
@@ -103,3 +103,16 @@ func TestString_EndsWith(t *testing.T) {
 	assert.False(t, s.Parse("TEST").IsValid())
 	assert.False(t, s.Parse("3tes3t").IsValid())
 }
+
+type CatalogueMarginLevel string
+type CatalogueMargin int
+
+func TestString_CustomPrimitive(t *testing.T) {
+	s := schema.String()
+
+	v := CatalogueMarginLevel("eebofleebo")
+	x := CatalogueMargin(123)
+
+	assert.True(t, s.Parse(v).IsValid())
+	assert.False(t, s.Parse(x).IsValid())
+}


### PR DESCRIPTION
Addresses: https://github.com/Jamess-Lucass/validator-go/issues/15 

This pull request includes changes to the `schema.go` and `string_test.go` files to improve type handling and add new test cases. The most important changes include enhancing the type checking in the `Parse` method and adding a new test for custom primitive types.

Improvements to type handling:

* [`schema.go`](diffhunk://#diff-c3b0d951288715c695f51ce2727c87a056e89ccbb4f3003be71baa8b405383e9R52-R54): Enhanced the `Parse` method in the `Schema` struct to improve type checking by comparing the kind of the value with the expected type.

New test cases:

* [`string_test.go`](diffhunk://#diff-4d13cdd83a4692949597600d231d19f247441928abcd4ea668ed02024e4822c0R106-R118): Added a new test function `TestString_CustomPrimitive` to validate custom primitive types such as `CatalogueMarginLevel` and `CatalogueMargin`.